### PR TITLE
文字数カウンタ機能の追加

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -84,4 +84,7 @@ footer{
       display: block;
     }
   }
+  .button{
+    margin-top: 10px;
+  }
 }

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -7,6 +7,7 @@ body{
 
 .content{
   min-height: calc(100vh - 24px);
+  overflow: hidden;
 }
 
 .header_logo{

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -1,4 +1,4 @@
-/* application */
+/* 全体 */
 body{
   margin: 0;
   padding: 0;
@@ -75,5 +75,13 @@ footer{
 .pages_about{
   .logo{
     width: 80%;
+  }
+}
+
+.tools_character_counter{
+  .chars_form{
+    .block{
+      display: block;
+    }
   }
 }

--- a/app/controllers/tools/character_counters_controller.rb
+++ b/app/controllers/tools/character_counters_controller.rb
@@ -5,7 +5,6 @@ module Tools
     end
 
     def create
-      @characters = character_counter[:characters]
       @character_counter = Tools::CharacterCounter.new(character_counter)
       render partial: 'count'
     end
@@ -13,7 +12,7 @@ module Tools
     private
 
     def character_counter
-      params.require(:tools_character_counter).permit(:characters)
+      params.require(:tools_character_counter).permit(%i(characters upper_limit))
     end
   end
 end

--- a/app/controllers/tools/character_counters_controller.rb
+++ b/app/controllers/tools/character_counters_controller.rb
@@ -1,4 +1,9 @@
 class Tools::CharacterCountersController < ApplicationController
   def show
+    @character_counter = Tools::CharacterCounter.new
+  end
+
+  def create
+    
   end
 end

--- a/app/controllers/tools/character_counters_controller.rb
+++ b/app/controllers/tools/character_counters_controller.rb
@@ -1,0 +1,4 @@
+class Tools::CharacterCountersController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/tools/character_counters_controller.rb
+++ b/app/controllers/tools/character_counters_controller.rb
@@ -1,16 +1,19 @@
-class Tools::CharacterCountersController < ApplicationController
-  def show
-    @character_counter = Tools::CharacterCounter.new
-  end
+module Tools
+  class CharacterCountersController < ApplicationController
+    def show
+      @character_counter = Tools::CharacterCounter.new
+    end
 
-  def create
-    @characters = character_counter[:characters]
-    @character_counter = Tools::CharacterCounter.new(character_counter)
-    render partial: 'count'
-  end
+    def create
+      @characters = character_counter[:characters]
+      @character_counter = Tools::CharacterCounter.new(character_counter)
+      render partial: 'count'
+    end
 
-  private
-  def character_counter
-    params.require(:tools_character_counter).permit(:characters)
+    private
+
+    def character_counter
+      params.require(:tools_character_counter).permit(:characters)
+    end
   end
 end

--- a/app/controllers/tools/character_counters_controller.rb
+++ b/app/controllers/tools/character_counters_controller.rb
@@ -4,6 +4,11 @@ class Tools::CharacterCountersController < ApplicationController
   end
 
   def create
-    
+    @characters = character_counter[:characters]
+  end
+
+  private
+  def character_counter
+    params.require(:tools_character_counter).permit(:characters)
   end
 end

--- a/app/controllers/tools/character_counters_controller.rb
+++ b/app/controllers/tools/character_counters_controller.rb
@@ -12,7 +12,7 @@ module Tools
     private
 
     def character_counter
-      params.require(:tools_character_counter).permit(%i(characters upper_limit))
+      params.require(:tools_character_counter).permit(%i[characters upper_limit])
     end
   end
 end

--- a/app/controllers/tools/character_counters_controller.rb
+++ b/app/controllers/tools/character_counters_controller.rb
@@ -5,6 +5,8 @@ class Tools::CharacterCountersController < ApplicationController
 
   def create
     @characters = character_counter[:characters]
+    @character_counter = Tools::CharacterCounter.new(character_counter)
+    render partial: 'count'
   end
 
   private

--- a/app/helpers/tools/character_counters_helper.rb
+++ b/app/helpers/tools/character_counters_helper.rb
@@ -1,0 +1,2 @@
+module Tools::CharacterCountersHelper
+end

--- a/app/helpers/tools/character_counters_helper.rb
+++ b/app/helpers/tools/character_counters_helper.rb
@@ -1,2 +1,4 @@
-module Tools::CharacterCountersHelper
+module Tools
+  module CharacterCountersHelper
+  end
 end

--- a/app/models/tools/character_counter.rb
+++ b/app/models/tools/character_counter.rb
@@ -13,9 +13,7 @@ module Tools
     def calc_remains_of_upper_limit
       upper_limit = self.upper_limit.to_i
 
-      if upper_limit <= 0
-        return nil
-      end
+      return nil if upper_limit <= 0
 
       upper_limit - count_characters
     end
@@ -23,11 +21,9 @@ module Tools
     def calc_ratio_of_characters_to_upper_limit
       upper_limit = self.upper_limit.to_i
 
-      if upper_limit <= 0
-        return nil
-      end
+      return nil if upper_limit <= 0
 
-      (count_characters.to_f/upper_limit*100).round(2)
+      (count_characters.to_f / upper_limit * 100).round(2)
     end
   end
 end

--- a/app/models/tools/character_counter.rb
+++ b/app/models/tools/character_counter.rb
@@ -1,10 +1,33 @@
 module Tools
   class CharacterCounter
     include ActiveModel::Model
-    attr_accessor :characters
+    attr_accessor :characters, :upper_limit
+
+    validates :characters, presence: true
+    validates :upper_limit, presence: true
 
     def count_characters
       characters.length
+    end
+
+    def calc_remains_of_upper_limit
+      upper_limit = self.upper_limit.to_i
+
+      if upper_limit <= 0
+        return nil
+      end
+
+      upper_limit - count_characters
+    end
+
+    def calc_ratio_of_characters_to_upper_limit
+      upper_limit = self.upper_limit.to_i
+
+      if upper_limit <= 0
+        return nil
+      end
+
+      (count_characters.to_f/upper_limit*100).round(2)
     end
   end
 end

--- a/app/models/tools/character_counter.rb
+++ b/app/models/tools/character_counter.rb
@@ -1,2 +1,4 @@
-class Tools::CharacterCounter < ApplicationRecord
+class Tools::CharacterCounter
+  include ActiveModel::Model
+  attr_accessor :characters
 end

--- a/app/models/tools/character_counter.rb
+++ b/app/models/tools/character_counter.rb
@@ -1,8 +1,10 @@
-class Tools::CharacterCounter
-  include ActiveModel::Model
-  attr_accessor :characters
+module Tools
+  class CharacterCounter
+    include ActiveModel::Model
+    attr_accessor :characters
 
-  def count_characters
-    characters.length
+    def count_characters
+      characters.length
+    end
   end
 end

--- a/app/models/tools/character_counter.rb
+++ b/app/models/tools/character_counter.rb
@@ -1,0 +1,2 @@
+class Tools::CharacterCounter < ApplicationRecord
+end

--- a/app/models/tools/character_counter.rb
+++ b/app/models/tools/character_counter.rb
@@ -1,4 +1,8 @@
 class Tools::CharacterCounter
   include ActiveModel::Model
   attr_accessor :characters
+
+  def count_characters
+    characters.length
+  end
 end

--- a/app/views/shared/_nav_links.html.slim
+++ b/app/views/shared/_nav_links.html.slim
@@ -1,2 +1,3 @@
 li = link_to '記事一覧', '#'
+li = link_to '文字数カウンター', tools_character_counter_path
 li = link_to 'ほしのなか政府について', about_path

--- a/app/views/tools/character_counters/_count.html.slim
+++ b/app/views/tools/character_counters/_count.html.slim
@@ -2,4 +2,6 @@
   = render partial: 'form'
   h2 出力
   ul 
-    li = "文字数: #{@character_counter.count_characters}"
+    li = "文字数: #{@character_counter.count_characters}字"
+    li = "上限まで残り: #{@character_counter.calc_remains_of_upper_limit}字"
+    li = "上限との比率: #{@character_counter.calc_ratio_of_characters_to_upper_limit}%"

--- a/app/views/tools/character_counters/_count.html.slim
+++ b/app/views/tools/character_counters/_count.html.slim
@@ -1,0 +1,10 @@
+= turbo_frame_tag 'count' do
+  = form_with model: @character_counter, url: tools_character_counter_path, method: :post, class: 'chars_form' do |f|
+    .input
+      = f.label :characters, '文字列', class: 'block'
+      = f.text_area :characters
+    .button
+      = f.submit 'カウント'
+  h2 出力
+  ul 
+    li = "文字数: #{@character_counter.count_characters}"

--- a/app/views/tools/character_counters/_count.html.slim
+++ b/app/views/tools/character_counters/_count.html.slim
@@ -1,10 +1,5 @@
 = turbo_frame_tag 'count' do
-  = form_with model: @character_counter, url: tools_character_counter_path, method: :post, class: 'chars_form' do |f|
-    .input
-      = f.label :characters, '文字列', class: 'block'
-      = f.text_area :characters
-    .button
-      = f.submit 'カウント'
+  = render partial: 'form'
   h2 出力
   ul 
     li = "文字数: #{@character_counter.count_characters}"

--- a/app/views/tools/character_counters/_form.html.slim
+++ b/app/views/tools/character_counters/_form.html.slim
@@ -1,0 +1,6 @@
+= form_with model: @character_counter, url: tools_character_counter_path, method: :post, class: 'chars_form' do |f|
+  .input
+    = f.label :characters, '文字列', class: 'block'
+    = f.text_area :characters
+  .button
+    = f.submit 'カウント'

--- a/app/views/tools/character_counters/_form.html.slim
+++ b/app/views/tools/character_counters/_form.html.slim
@@ -2,5 +2,7 @@
   .input
     = f.label :characters, '文字列', class: 'block'
     = f.text_area :characters
+    = f.label :upper_limit, '字数上限', class: 'block'
+    = f.number_field :upper_limit
   .button
     = f.submit 'カウント'

--- a/app/views/tools/character_counters/show.html.slim
+++ b/app/views/tools/character_counters/show.html.slim
@@ -3,7 +3,7 @@
   p 文字数のカウントにお使いください。
 
   h2 入力
-  = form_with model: @characters_counter, method: :post, class: 'chars_form' do |f|
+  = form_with model: @character_counter, url: tools_character_counter_path, method: :post, class: 'chars_form' do |f|
     .input
       = f.label :characters, '文字列', class: 'block'
       = f.text_area :characters

--- a/app/views/tools/character_counters/show.html.slim
+++ b/app/views/tools/character_counters/show.html.slim
@@ -1,12 +1,7 @@
 .tools_character_counter
-  h1 文字数カウント
-  p 文字数のカウントにお使いください。
+  h1 文字数カウンター
+  p 文字数のカウントにお使いください。改行・空白は全て1字とカウントされます。
 
   h2 入力
   = turbo_frame_tag 'count' do
-    = form_with model: @character_counter, url: tools_character_counter_path, method: :post, class: 'chars_form' do |f|
-      .input
-        = f.label :characters, '文字列', class: 'block'
-        = f.text_area :characters
-      .button
-        = f.submit 'カウント'
+    = render partial: 'form'

--- a/app/views/tools/character_counters/show.html.slim
+++ b/app/views/tools/character_counters/show.html.slim
@@ -1,2 +1,13 @@
-h1 Tools::CharacterCounters#show
-p Find me in app/views/tools/character_counters/show.html.slim
+.tools_character_counter
+  h1 文字数カウント
+  p 文字数のカウントにお使いください。
+
+  h2 入力
+  = form_with model: @characters_counter, method: :post, class: 'chars_form' do |f|
+    .input
+      = f.label :characters, '文字列', class: 'block'
+      = f.text_area :characters
+    .button
+      = f.submit 'カウント'
+
+  h2 結果

--- a/app/views/tools/character_counters/show.html.slim
+++ b/app/views/tools/character_counters/show.html.slim
@@ -3,11 +3,10 @@
   p 文字数のカウントにお使いください。
 
   h2 入力
-  = form_with model: @character_counter, url: tools_character_counter_path, method: :post, class: 'chars_form' do |f|
-    .input
-      = f.label :characters, '文字列', class: 'block'
-      = f.text_area :characters
-    .button
-      = f.submit 'カウント'
-
-  h2 結果
+  = turbo_frame_tag 'count' do
+    = form_with model: @character_counter, url: tools_character_counter_path, method: :post, class: 'chars_form' do |f|
+      .input
+        = f.label :characters, '文字列', class: 'block'
+        = f.text_area :characters
+      .button
+        = f.submit 'カウント'

--- a/app/views/tools/character_counters/show.html.slim
+++ b/app/views/tools/character_counters/show.html.slim
@@ -1,0 +1,2 @@
+h1 Tools::CharacterCounters#show
+p Find me in app/views/tools/character_counters/show.html.slim

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,6 @@ Rails.application.routes.draw do
   get "links" => "pages#links"
 
   namespace :tools do
-    resource :character_counter, only: :show
+    resource :character_counter, only: %i[show create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,8 @@ Rails.application.routes.draw do
   root "pages#top"
   get "about" => "pages#about"
   get "links" => "pages#links"
+
+  namespace :tools do
+    resource :character_counter, only: :show
+  end
 end

--- a/spec/factories/tools/character_counters.rb
+++ b/spec/factories/tools/character_counters.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :tools_character_counter, class: 'Tools::CharacterCounter' do
     characters { 'characters' }
+    upper_limit { '' }
   end
 end

--- a/spec/factories/tools/character_counters.rb
+++ b/spec/factories/tools/character_counters.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :tools_character_counter, class: 'Tools::CharacterCounter' do
-    
+    characters { 'characters' }
   end
 end

--- a/spec/factories/tools/character_counters.rb
+++ b/spec/factories/tools/character_counters.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tools_character_counter, class: 'Tools::CharacterCounter' do
+    
+  end
+end

--- a/spec/helpers/tools/character_counters_helper_spec.rb
+++ b/spec/helpers/tools/character_counters_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Tools::CharacterCountersHelper. For example:
+#
+# describe Tools::CharacterCountersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Tools::CharacterCountersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/tools/character_counters_helper_spec.rb
+++ b/spec/helpers/tools/character_counters_helper_spec.rb
@@ -10,6 +10,6 @@ require 'rails_helper'
 #     end
 #   end
 # end
-RSpec.describe Tools::CharacterCountersHelper, type: :helper do
+RSpec.describe Tools::CharacterCountersHelper do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/tools/character_counter_spec.rb
+++ b/spec/models/tools/character_counter_spec.rb
@@ -23,4 +23,25 @@ RSpec.describe Tools::CharacterCounter do
       end
     end
   end
+
+  describe '#compare_characters_to_upper_limit' do
+    context 'when upper limit is empty' do
+      context 'with 10 characters input' do
+        it 'returns nil' do
+          counter = build(:tools_character_counter)
+          expect(counter.compare_characters_to_upper_limit).to be nil
+        end
+      end
+    end
+
+    context 'when upper limit is 100' do
+      context 'with 10 characters input' do
+        it 'returns 10' do
+          counter = build(:tools_character_counter, upper_limit: '100')
+          expect(counter.compare_characters_to_upper_limit).to eq 10
+        end
+      end
+    end
+
+  end
 end

--- a/spec/models/tools/character_counter_spec.rb
+++ b/spec/models/tools/character_counter_spec.rb
@@ -1,5 +1,26 @@
 require 'rails_helper'
 
-RSpec.describe Tools::CharacterCounter, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe Tools::CharacterCounter do
+  describe '#count_characters' do
+    context 'when "characters" input' do
+      it 'returns 10' do
+        counter = build(:tools_character_counter)
+        expect(counter.count_characters).to eq 10
+      end
+    end
+
+    context 'when very long characters input' do
+      it 'returns 1234' do
+        counter = build(:tools_character_counter, characters: 'a' * 1234)
+        expect(counter.count_characters).to eq 1234
+      end
+    end
+
+    context 'when empty strings input' do
+      it 'returns 0' do
+        counter = build(:tools_character_counter, characters: '')
+        expect(counter.count_characters).to eq 0
+      end
+    end
+  end
 end

--- a/spec/models/tools/character_counter_spec.rb
+++ b/spec/models/tools/character_counter_spec.rb
@@ -24,24 +24,91 @@ RSpec.describe Tools::CharacterCounter do
     end
   end
 
-  describe '#compare_characters_to_upper_limit' do
+  describe '#calc_remains_of_upper_limit' do
     context 'when upper limit is empty' do
-      context 'with 10 characters input' do
-        it 'returns nil' do
-          counter = build(:tools_character_counter)
-          expect(counter.compare_characters_to_upper_limit).to be nil
-        end
+      it 'returns nil' do
+        counter = build(:tools_character_counter)
+        expect(counter.calc_remains_of_upper_limit).to be_nil
       end
     end
 
-    context 'when upper limit is 100' do
-      context 'with 10 characters input' do
-        it 'returns 10' do
-          counter = build(:tools_character_counter, upper_limit: '100')
-          expect(counter.compare_characters_to_upper_limit).to eq 10
-        end
+    context 'when upper limit is 15' do
+      it 'returns 5' do
+        counter = build(:tools_character_counter, upper_limit: '15')
+        expect(counter.calc_remains_of_upper_limit).to be 5
       end
     end
 
+    context 'when upper limit is 10' do
+      it 'returns 0' do
+        counter = build(:tools_character_counter, upper_limit: '10')
+        expect(counter.calc_remains_of_upper_limit).to be 0
+      end
+    end
+
+    context 'when upper limit is 5' do
+      it 'returns -5' do
+        counter = build(:tools_character_counter, upper_limit: '5')
+        expect(counter.calc_remains_of_upper_limit).to be(-5)
+      end
+    end
+
+    context 'when upper limit is 0' do
+      it 'returns nil' do
+        counter = build(:tools_character_counter, upper_limit: '0')
+        expect(counter.calc_remains_of_upper_limit).to be_nil
+      end
+    end
+
+    context 'when upper limit is -5' do
+      it 'returns nil' do
+        counter = build(:tools_character_counter, upper_limit: '-5')
+        expect(counter.calc_remains_of_upper_limit).to be_nil
+      end
+    end
+  end
+
+  describe '#calc_ratio_of_characters_to_upper_limit' do
+    context 'when upper limit is empty' do
+      it 'returns nil' do
+        counter = build(:tools_character_counter, upper_limit: '')
+        expect(counter.calc_ratio_of_characters_to_upper_limit).to be_nil
+      end
+    end
+
+    context 'when upper limit is 15' do
+      it 'returns 66.67' do
+        counter = build(:tools_character_counter, upper_limit: '15')
+        expect(counter.calc_ratio_of_characters_to_upper_limit).to be 66.67
+      end
+    end
+
+    context 'when upper limit is 10' do
+      it 'returns 100.0' do
+        counter = build(:tools_character_counter, upper_limit: '10')
+        expect(counter.calc_ratio_of_characters_to_upper_limit).to be 100.0
+      end
+    end
+
+    context 'when upper limit is 5' do
+      it 'returns 200.0' do
+        counter = build(:tools_character_counter, upper_limit: '5')
+        expect(counter.calc_ratio_of_characters_to_upper_limit).to be 200.0
+      end
+    end
+
+    context 'when upper limit is 0' do
+      it 'returns nil' do
+        counter = build(:tools_character_counter, upper_limit: '0')
+        expect(counter.calc_ratio_of_characters_to_upper_limit).to be_nil
+      end
+    end
+
+    context 'when upper limit is -5' do
+      it 'returns nil' do
+        counter = build(:tools_character_counter, upper_limit: '-5')
+        expect(counter.calc_ratio_of_characters_to_upper_limit).to be_nil
+      end
+    end
   end
 end

--- a/spec/models/tools/character_counter_spec.rb
+++ b/spec/models/tools/character_counter_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tools::CharacterCounter, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/tools/character_counters_spec.rb
+++ b/spec/requests/tools/character_counters_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Tools::CharacterCounters", type: :request do
+  describe "GET /show" do
+    it "returns http success" do
+      get "/tools/character_counters/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/tools/character_counters_spec.rb
+++ b/spec/requests/tools/character_counters_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe "Tools::CharacterCounters", type: :request do
-  describe "GET /" do
-    it "returns http success" do
-      get "/tools/character_counter/"
+RSpec.describe 'Tools::CharacterCounters' do
+  describe 'GET /' do
+    it 'returns http success' do
+      get '/tools/character_counter/'
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/tools/character_counters_spec.rb
+++ b/spec/requests/tools/character_counters_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe "Tools::CharacterCounters", type: :request do
-  describe "GET /show" do
+  describe "GET /" do
     it "returns http success" do
-      get "/tools/character_counters/show"
+      get "/tools/character_counter/"
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/views/tools/character_counters/show.html.slim_spec.rb
+++ b/spec/views/tools/character_counters/show.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "character_counters/show.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/tools/character_counters/show.html.slim_spec.rb
+++ b/spec/views/tools/character_counters/show.html.slim_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "character_counters/show.html.slim", type: :view do
+RSpec.describe 'character_counters/show.html.slim' do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] 各Issueのテスト項目をリリース後に確認するもの以外すべて満たしている
- [x] 実装したページや機能をWikiに掲載した／ページや機能は実装していない
# Issue
- fix #3
- #31 
## 目的
文字数カウンタ機能を追加する
## 実装詳細
- /tools/character_counter に文字数カウンターを追加した
  - 文字列の入力と字数の上限設定を行える
  - 出力はTurbo Frameにより、字数と上限との差、上限との比を算出する
  - 上限は任意設定で、空や無効な値の時には文字数のみ表示される
## 動作
- 上限あり
![2024-01-09 (1)](https://github.com/Snak0201/fpb-wwwsite/assets/79178318/20078ac0-506b-49fe-9b5b-8ff1bdf3f11c)
- 上限なし
![2024-01-09](https://github.com/Snak0201/fpb-wwwsite/assets/79178318/9d56601f-af8b-418a-a931-0cbeb3087ede)
## リリース対応
### 種別（選択）
必要（正式リリース）
### 追加作業
- #31 のスマホでの確認
  - 修正済みならIssueを完了にする
## メモ
