### PR TITLE
capistrano-rails-console gemの追加

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -33,6 +33,7 @@ require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 # require "capistrano/passenger"
+require 'capistrano/rails/console'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rb').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ group :development do
   gem 'capistrano-rails'
   gem 'capistrano-rbenv'
   gem 'web-console'
+  gem 'capistrano-rails-console', require: false
 
   gem 'bcrypt_pbkdf'
   gem 'ed25519'

--- a/Gemfile
+++ b/Gemfile
@@ -69,9 +69,9 @@ group :development do
   gem 'capistrano'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
+  gem 'capistrano-rails-console', require: false
   gem 'capistrano-rbenv'
   gem 'web-console'
-  gem 'capistrano-rails-console', require: false
 
   gem 'bcrypt_pbkdf'
   gem 'ed25519'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,9 @@ GEM
     capistrano-rails (1.6.3)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
+    capistrano-rails-console (2.3.0)
+      capistrano (>= 3.5.0, < 4.0.0)
+      sshkit-interactive (~> 0.3.0)
     capistrano-rbenv (2.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
@@ -302,6 +305,8 @@ GEM
       mutex_m
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    sshkit-interactive (0.3.0)
+      sshkit (~> 1.12)
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -347,6 +352,7 @@ DEPENDENCIES
   capistrano
   capistrano-bundler
   capistrano-rails
+  capistrano-rails-console
   capistrano-rbenv
   capybara
   debug

--- a/README.md
+++ b/README.md
@@ -28,10 +28,15 @@
 ※ `-a`オプションで自動修正できますが、変な修正になることもあります。
 
 ## RSpecによるテスト方法
-`docker compose run --rm app bundle exec rspec`
+`docker compose run --rm app bundle exec rspec`を実行します。
 
 ## 本番環境へのデプロイ（リリース）方法
 1. 対象のコードをmainブランチに反映します（プルリクエストが**必須**です）
 1. GitHub上でReleaseを作成します。バージョンは[Wiki](https://github.com/Snak0201/fpb-wwwsite/wiki/%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%AE%E4%BB%98%E3%81%91%E6%96%B9#%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%8B%E3%83%B3%E3%82%B0%E3%81%AE%E4%BB%95%E6%96%B9)に従って作成します。
 1. ローカルで`docker compose run --rm app bundle exec cap production deploy`を実行します
 1. （不具合が起きた場合）動作確認後、`docker compose run --rm app bundle exec cap production deploy:rollback`でロールバックを行います
+
+## 本番環境のコンソールへのアクセス方法
+`docker compose run --rm app bundle exec cap production rails:console`を実行します
+
+※ WARNING: UNPROTECTED PRIVATE KEY FILE!が出る場合、`docker compose run --rm app chmod 600 /root/.ssh/fpb-wwwsite_conoha/id_rsa`を実行します


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] 各Issueのテスト項目をリリース後に確認するもの以外すべて満たしている
- [x] 実装したページや機能をWikiに掲載した／ページや機能は実装していない
# Issue
- fix #48 
## 目的
- 開発者が本番環境のコンソールにアクセスできるようにする
## 実装詳細
- capistrano-rails-console Gemを追加した
  - https://hobbyworks.hatenablog.com/entry/2018/04/21/141942
- READMEを追加した
## 動作
- [x] READMEの内容を実行すると本番環境のコンソールを実行できる
## リリース対応
### 種別（選択）
不要
### 追加作業
## メモ
