### PR TITLE
開発者が記事に局を追加できる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,52 @@ jobs:
       - name: Run rspec
         run: bundle exec rspec spec/requests
 
+  rspec-model:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0.35
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 1
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 10
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Bundler and gem install
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3 --path vendor/bundle
+
+      - name: Yarn install
+        run: yarn install --check-files
+
+      - name: Database create and migrate
+        run: |
+          cp config/database.yml.ci config/database.yml
+          bundle exec rails db:create RAILS_ENV=test
+          bundle exec rails db:migrate RAILS_ENV=test
+
+      - name: Run rspec
+        run: bundle exec rspec spec/models
+      
+
   rspec-system:
     runs-on: ubuntu-latest
     services:

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,2 +1,5 @@
 class Article < ApplicationRecord
+  has_many :bureau_articles, class_name: 'BureauArticle', foreign_key: :bureau_id, inverse_of: :article,
+                             dependent: :destroy
+  has_many :bureaus, through: :bureau_articles
 end

--- a/app/models/bureau.rb
+++ b/app/models/bureau.rb
@@ -1,0 +1,2 @@
+class Bureau < ApplicationRecord
+end

--- a/app/models/bureau.rb
+++ b/app/models/bureau.rb
@@ -1,2 +1,4 @@
 class Bureau < ApplicationRecord
+  has_many :bureau_articles, dependent: :destroy
+  has_many :articles, through: :bureau_articles
 end

--- a/app/models/bureau_article.rb
+++ b/app/models/bureau_article.rb
@@ -1,0 +1,4 @@
+class BureauArticle < ApplicationRecord
+  belongs_to :bureau
+  belongs_to :article
+end

--- a/db/migrate/20240126095209_create_bureaus.rb
+++ b/db/migrate/20240126095209_create_bureaus.rb
@@ -1,0 +1,14 @@
+class CreateBureaus < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bureaus do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.text :content
+
+      t.timestamps
+    end
+
+    add_index :bureaus, :name, unique: true
+    add_index :bureaus, :slug, unique: true
+  end
+end

--- a/db/migrate/20240127055304_create_bureau_articles.rb
+++ b/db/migrate/20240127055304_create_bureau_articles.rb
@@ -1,0 +1,10 @@
+class CreateBureauArticles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bureau_articles do |t|
+      t.references :bureau, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240127084757_add_index_to_bureau_articles.rb
+++ b/db/migrate/20240127084757_add_index_to_bureau_articles.rb
@@ -1,0 +1,5 @@
+class AddIndexToBureauArticles < ActiveRecord::Migration[7.0]
+  def change
+    add_index :bureau_articles, [:bureau_id, :article_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_12_151719) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_26_095209) do
   create_table "admins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -37,6 +37,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_12_151719) do
     t.datetime "updated_at", null: false
     t.index ["number"], name: "index_articles_on_number"
     t.index ["title"], name: "index_articles_on_title"
+  end
+
+  create_table "bureaus", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_bureaus_on_name", unique: true
+    t.index ["slug"], name: "index_bureaus_on_slug", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_26_095209) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_27_055304) do
   create_table "admins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -39,6 +39,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_26_095209) do
     t.index ["title"], name: "index_articles_on_title"
   end
 
+  create_table "bureau_articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "bureau_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_bureau_articles_on_article_id"
+    t.index ["bureau_id"], name: "index_bureau_articles_on_bureau_id"
+  end
+
   create_table "bureaus", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
@@ -49,4 +58,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_26_095209) do
     t.index ["slug"], name: "index_bureaus_on_slug", unique: true
   end
 
+  add_foreign_key "bureau_articles", "articles"
+  add_foreign_key "bureau_articles", "bureaus"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_27_055304) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_27_084757) do
   create_table "admins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_27_055304) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["article_id"], name: "index_bureau_articles_on_article_id"
+    t.index ["bureau_id", "article_id"], name: "index_bureau_articles_on_bureau_id_and_article_id", unique: true
     t.index ["bureau_id"], name: "index_bureau_articles_on_bureau_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,15 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-Article.find_or_create_by({ id: 0, title: 'デフォルト記事', content: 'この記事はデフォルト記事です。' })
+# seedの内容
+Article.find_or_create_by({ id: 0, title: 'テスト用記事', content: 'この記事はテスト用記事です。' })
+
+Bureau.find_or_create_by({ id: 1, name: '総務局', slug: 'general' })
+Bureau.find_or_create_by({ id: 2, name: '財務局', slug: 'finance' })
+Bureau.find_or_create_by({ id: 3, name: '法務局', slug: 'justice' })
+Bureau.find_or_create_by({ id: 4, name: '医務局', slug: 'medical' })
+Bureau.find_or_create_by({ id: 5, name: '労務局', slug: 'labor' })
+Bureau.find_or_create_by({ id: 6, name: '学務局', slug: 'education' })
+Bureau.find_or_create_by({ id: 7, name: '外交局', slug: 'foreign' })
+Bureau.find_or_create_by({ id: 8, name: '娯楽局', slug: 'entertainment' })
+Bureau.find_or_create_by({ id: 9, name: '広報局', slug: 'publish' })

--- a/spec/factories/bureau_articles.rb
+++ b/spec/factories/bureau_articles.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :bureau_article do
-    bureau { nil }
-    article { nil }
+    bureau
+    article
   end
 end

--- a/spec/factories/bureau_articles.rb
+++ b/spec/factories/bureau_articles.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :bureau_article do
+    bureau { nil }
+    article { nil }
+  end
+end

--- a/spec/factories/bureaus.rb
+++ b/spec/factories/bureaus.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :bureau do
-    name { "MyString" }
-    slug { "MyString" }
-    content { "MyText" }
+    name { 'MyString' }
+    slug { 'MyString' }
+    content { 'MyText' }
   end
 end

--- a/spec/factories/bureaus.rb
+++ b/spec/factories/bureaus.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :bureau do
+    name { "MyString" }
+    slug { "MyString" }
+    content { "MyText" }
+  end
+end

--- a/spec/factories/bureaus.rb
+++ b/spec/factories/bureaus.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :bureau do
-    name { 'MyString' }
-    slug { 'MyString' }
-    content { 'MyText' }
+    name { 'Test Bureau' }
+    slug { 'test' }
+    content { "Test Bureau's content" }
   end
 end

--- a/spec/models/bureau_article_spec.rb
+++ b/spec/models/bureau_article_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Bureau do
+RSpec.describe BureauArticle do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/bureau_article_spec.rb
+++ b/spec/models/bureau_article_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe BureauArticle do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:bureau) { create(:bureau) }
+  let(:article) { create(:article) }
+
+  context 'when create same records' do
+    it 'raises error' do
+      create(:bureau_article, bureau:, article:)
+      expect { create(:bureau_article, bureau:, article:) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
 end

--- a/spec/models/bureau_spec.rb
+++ b/spec/models/bureau_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Bureau, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/bureau_spec.rb
+++ b/spec/models/bureau_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Bureau do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] 各Issueのテスト項目をリリース後に確認するもの以外すべて満たしている
- [x] 実装したページや機能をWikiに掲載した／ページや機能は実装していない
# Issue
- Fixes #52
## 目的
既存の記事モデルに局モデルを関連付けることができるようになる
## 実装詳細
- 局（Bureau）モデルを追加
- 中間モデル（BureauArticle）を追加
- 関連付けを追加
## 動作
- [x] 開発者が局を追加できる
- [x] 記事から局、局から記事をたどることができる
## リリース対応
### 種別（選択）
必要（プレリリース）
### 追加作業
- seedの投入
## メモ
