### PR TITLE
スタミナ計算機の出力を修正

### DIFF
--- a/app/views/tools/stamina_calculators/_output.html.slim
+++ b/app/views/tools/stamina_calculators/_output.html.slim
@@ -7,5 +7,5 @@
     li 下記の時間に回復が完了する予定です。
     ul 
       li 
-        strong = l Time.zone.now
+        strong = l @calculator.recover_at
       li = "約 #{@recover_time[:hours]} 時間 #{@recover_time[:minutes]} 分 #{@recover_time[:seconds]} 秒後"


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] fixする各Issueの受け入れ条件をすべて満たしている
- [x] 実装ページや機能があればそれをWikiに掲載した
# Issue
- fix #93 
## 目的
スタミナ計算機の出力を計算結果に修正する
## 実装詳細
- app/views/tools/stamina_calculators/_output.html.slim
  - 常に`Time.zone.now`を出力していた
## 動作
- [x] 計算された時間が正しく表示される

## レビュー観点

## デプロイ種別
### 種別（選択）
リリース
### 追加作業／確認項目
- 
## メモ
