### PR TITLE
管理画面の記事一覧を表にする

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -142,3 +142,19 @@ footer{
     width: 80%;
   }
 }
+
+.admin_articles{
+  .scroll_content{
+    overflow-x: auto;
+  }
+
+  .articles{
+    min-width: 1200px;
+    border-spacing: 0;
+
+    th, td{
+      border-bottom: 1px solid gray;
+      padding: 5px;
+    }
+  }
+}

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -5,6 +5,15 @@ body{
   font-family:'メイリオ','Meiryo','Meiryo UI','ＭＳ ゴシック','Hiragino Kaku Gothic ProN','ヒラギノ角ゴ ProN W3',sans-serif;
 }
 
+table{
+  border-spacing: 0;
+
+  & th, td{
+    border-bottom: 1px solid gray;
+    padding: 5px;
+  }
+}
+
 .content{
   min-height: calc(100vh - 24px);
   overflow: hidden;
@@ -144,7 +153,7 @@ footer{
 }
 
 .admin_articles{
-  .scroll_content{
+  .scroll_table{
     overflow-x: auto;
   }
 

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -153,17 +153,12 @@ footer{
 }
 
 .admin_articles{
-  .scroll_table{
+  .scroll_content{
     overflow-x: auto;
   }
 
   .articles{
     min-width: 1200px;
     border-spacing: 0;
-
-    th, td{
-      border-bottom: 1px solid gray;
-      padding: 5px;
-    }
   }
 }

--- a/app/helpers/admins/articles_helper.rb
+++ b/app/helpers/admins/articles_helper.rb
@@ -1,4 +1,9 @@
 module Admins
   module ArticlesHelper
+    def publish_status(published_at)
+      return '非公開' if published_at.nil?
+
+      '公開'
+    end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,7 +6,7 @@ class Article < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :number, presence: true
 
-  scope :admin_index, -> { order(published_at: :desc) }
+  scope :admin_index, -> { order(created_at: :desc) }
   scope :published, -> { where.not(published_at: nil) }
   scope :newer, -> { published.order(published_at: :desc) }
   scope :newest, -> { newer.limit(5) }

--- a/app/views/admins/articles/index.html.slim
+++ b/app/views/admins/articles/index.html.slim
@@ -14,7 +14,7 @@
           th 更新日時
       tbody 
         - @articles.each do |article|
-          tr align="center"
+          tr id="article_#{article.id}" align="center"
             td align="right" = article.id 
             td = link_to article.title, admin_article_path(article)
             td 

--- a/app/views/admins/articles/index.html.slim
+++ b/app/views/admins/articles/index.html.slim
@@ -1,7 +1,31 @@
-h1 記事一覧
-p = link_to '管理画面に戻る', admin_index_path
-ul 
-  - @articles.each do |article|
-    li = link_to article.title, admin_article_path(article)
-    
-= paginate @articles
+.admin_articles
+  h1 記事一覧
+  p = link_to '管理画面に戻る', admin_index_path
+
+  .scroll_content
+    table.articles 
+      thead 
+        tr 
+          th 記事ID 
+          th タイトル
+          th 管轄局
+          th ステータス
+          th 公開日時
+          th 更新日時
+      tbody 
+        - @articles.each do |article|
+          tr align="center"
+            td align="right" = article.id 
+            td = link_to article.title, admin_article_path(article)
+            td 
+              - article.bureaus.each do |bureau|
+                = "#{bureau.name} " 
+            td 公開
+            - if article.published_at.present?
+              td = l article.published_at, format: :short
+            - else 
+              td 公開されていません 
+            td = l article.updated_at, format: :short
+
+        
+    = paginate @articles

--- a/app/views/admins/articles/index.html.slim
+++ b/app/views/admins/articles/index.html.slim
@@ -20,7 +20,7 @@
             td 
               - article.bureaus.each do |bureau|
                 = "#{bureau.name} " 
-            td 公開
+            td = publish_status article.published_at
             - if article.published_at.present?
               td = l article.published_at, format: :short
             - else 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -210,3 +210,4 @@ ja:
   time:
     formats:
       default: "%Y年%m月%d日 %H時%M分"
+      short: "%Y/%m/%d %H:%M"

--- a/spec/system/admin/articles/index_spec.rb
+++ b/spec/system/admin/articles/index_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'articles index in admin page' do
   let(:unpublished_article) { create(:article) }
   let(:published_article) { create(:article, :published) }
 
-
   before do
     admin_log_in admin
     create_list(:bureau, 2)

--- a/spec/system/admin/articles/index_spec.rb
+++ b/spec/system/admin/articles/index_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'articles index in admin page' do
+  let(:admin) { create(:admin) }
+  let(:unpublished_article) { create(:article) }
+  let(:published_article) { create(:article, :published) }
+
+
+  before do
+    admin_log_in admin
+    create_list(:bureau, 2)
+    create(:bureau_article, bureau: Bureau.first, article: unpublished_article)
+    create(:bureau_article, bureau: Bureau.first, article: published_article)
+    create(:bureau_article, bureau: Bureau.second, article: published_article)
+  end
+
+  it 'has all articles and correct information' do
+    visit admin_articles_path
+    within "#article_#{unpublished_article.id}" do
+      expect(page).to have_content unpublished_article.id
+      expect(page).to have_content unpublished_article.title
+      unpublished_article.bureaus.each do |bureau|
+        expect(page).to have_content bureau.name
+      end
+      expect(page).to have_content '非公開'
+      expect(page).to have_content '公開されていません'
+      expect(page).to have_content I18n.l(unpublished_article.updated_at, format: :short)
+    end
+    within "#article_#{published_article.id}" do
+      expect(page).to have_content published_article.id
+      expect(page).to have_content published_article.title
+      published_article.bureaus.each do |bureau|
+        expect(page).to have_content bureau.name
+      end
+      expect(page).to have_content '公開'
+      expect(page).to have_content I18n.l(published_article.published_at, format: :short)
+      expect(page).to have_content I18n.l(published_article.updated_at, format: :short)
+    end
+  end
+end


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] fixする各Issueの受け入れ条件をすべて満たしている
- [x] 実装ページや機能があればそれをWikiに掲載した
# Issue
- fix #65 
## 目的
管理画面の記事一覧を見やすくする
## 実装詳細
- app/assets/stylesheets/custom.css
  - スクロールできるようにCSSを書く
  - マークダウンの表も含めて横罫線がつくようになった
- app/helpers/admins/articles_helper.rb
  - 公開・非公開を表示するヘルパーを追加
- app/models/article.rb
  - 表示順を作成が新しい順に変更（IDの降順）
- app/views/admins/articles/index.html.slim
  - 記事一覧を表にする
- config/locales/ja.yml
  - 日時のフォーマットに短縮形を追加
## 動作
- [x] 各記事の情報が記事一覧に正しく掲載されている
- [x] 公開・非公開の種別が正しい

## レビュー観点

## デプロイ種別
### 種別（選択）
リリース
### 追加作業／確認項目
- スマホでの表示を見てみる
## メモ
