### PR TITLE
graphqlをコンテナ間で反映できるようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,6 @@ module App
     config.i18n.default_locale = :ja
     # config.eager_load_paths << Rails.root.join("extras")
     
-    config.hosts << "wwwsite-app"
 
     config.action_view.sanitized_allowed_tags = Loofah::HTML5::SafeList::ALLOWED_ELEMENTS
     config.action_view.sanitized_allowed_attributes = Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,8 @@ module App
     config.time_zone = "Asia/Tokyo"
     config.i18n.default_locale = :ja
     # config.eager_load_paths << Rails.root.join("extras")
+    
+    config.hosts << "wwwsite-app"
 
     config.action_view.sanitized_allowed_tags = Loofah::HTML5::SafeList::ALLOWED_ELEMENTS
     config.action_view.sanitized_allowed_attributes = Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.hosts.clear
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - 3306:3306
     volumes:
       - mysql_db_volume:/var/lib/mysql
+    networks:
+      - wwwsite
 
   app:
     container_name: wwwsite-app
@@ -23,13 +25,22 @@ services:
       - 8000:3000
     depends_on:
       - db
-  
+    networks:
+      - wwwsite
+      - wwwsite_view
+
   browser:
     container_name: wwwsite-browser
     image: selenium/standalone-chrome-debug
-  
-
+    networks:
+      - wwwsite
 
 volumes:
   mysql_db_volume:
   rails_gem_volume:
+
+networks:
+  wwwsite:
+    name: wwwsite
+  wwwsite_view:
+    name: wwwsite_view


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] closeする各Issueの受け入れ条件をすべて満たしている
- [x] 実装ページや機能があればそれをWikiに掲載した
# Issue
- close Snak0201/fpb-wwwview#3
- Epic: 
## 目的
フロントエンドのコンテナからバックエンドのgraphqlにアクセスできるようにする
## 実装詳細
- 開発環境のみconfig.hostsをすべて許可する
- Dockerにネットワークを追加する
## 動作
- [x] CIがすべて通る

## レビュー観点

## デプロイ種別
### 種別（選択）
不要
### 追加作業／確認項目
- Snak0201/fpb-wwwview#4 と同時にマージする
## メモ
