### PR TITLE
#181 委員会のGraphQL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'sprockets-rails'
 gem 'mysql2', '~> 0.5'
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem 'puma', '~> 5.0'
+gem 'puma', '~> 5.6'
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem 'importmap-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     net-ssh (7.2.3)
-    nio4r (2.7.1)
+    nio4r (2.7.3)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -214,7 +214,7 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
-    puma (5.6.8)
+    puma (5.6.9)
       nio4r (~> 2.0)
     pundit (2.3.1)
       activesupport (>= 3.0.0)
@@ -423,7 +423,7 @@ DEPENDENCIES
   kaminari
   mysql2 (~> 0.5)
   paper_trail
-  puma (~> 5.0)
+  puma (~> 5.6)
   pundit
   rack-cors
   rails (~> 7.0.8)

--- a/app/graphql/resolvers/committee_resolver.rb
+++ b/app/graphql/resolvers/committee_resolver.rb
@@ -1,0 +1,12 @@
+module Resolvers
+  class CommitteeResolver < Resolvers::BaseResolver
+    description 'committee detail'
+
+    type Types::CommitteeType, null: true
+    argument :slug, String, required: true, description: 'slug'
+
+    def resolve(slug:)
+      Committee.find_by(slug:)
+    end
+  end
+end

--- a/app/graphql/resolvers/committees_resolver.rb
+++ b/app/graphql/resolvers/committees_resolver.rb
@@ -1,0 +1,11 @@
+module Resolvers
+  class CommitteesResolver < Resolvers::BaseResolver
+    description 'all committees list'
+
+    type [Types::CommitteeType], null: true
+
+    def resolve
+      Committee.sorted
+    end
+  end
+end

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -4,7 +4,8 @@ module Types
   class ArticleType < Types::BaseObject
     description 'published article on Hoshinonaka Government'
 
-    field :bureaus, [Types::BureauType], null: true, description: 'jurisdiction bureau'
+    field :bureaus, [Types::BureauType], null: true, description: 'jurisdiction bureaus'
+    field :committees, [Types::CommitteeType], null: true, description: 'jurisdiction committees'
     field :content, String, description: 'markdown content'
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'created at'
     field :id, ID, null: false, description: 'id'

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -14,6 +14,8 @@ module Types
     field :title, String, null: false, description: 'title'
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'updated at'
 
+    # NOTE: ArticleTypeから局や委員会を直接呼び出せるようにする
     delegate :bureaus, to: :object
+    delegate :committees, to: :object
   end
 end

--- a/app/graphql/types/committee_type.rb
+++ b/app/graphql/types/committee_type.rb
@@ -5,7 +5,7 @@ module Types
     description 'article tags'
 
     field :articles, Types::ArticleType.connection_type, null: true, description: 'committee articles list'
-    field :bureau_id, Integer, description: 'jurisdiction bureau id'
+    field :bureau, Types::BureauType, description: 'jurisdiction bureau'
     field :content, String, description: 'markdown content'
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'created_at'
     field :description, String, null: false, description: 'short description'

--- a/app/graphql/types/committee_type.rb
+++ b/app/graphql/types/committee_type.rb
@@ -4,6 +4,7 @@ module Types
   class CommitteeType < Types::BaseObject
     description 'article tags'
 
+    field :articles, [Types::ArticleType], description: 'committee articles list'
     field :bureau_id, Integer, description: 'jurisdiction bureau id'
     field :content, String, description: 'markdown content'
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'created_at'

--- a/app/graphql/types/committee_type.rb
+++ b/app/graphql/types/committee_type.rb
@@ -4,7 +4,7 @@ module Types
   class CommitteeType < Types::BaseObject
     description 'article tags'
 
-    field :articles, [Types::ArticleType], description: 'committee articles list'
+    field :articles, Types::ArticleType.connection_type, null: true, description: 'committee articles list'
     field :bureau_id, Integer, description: 'jurisdiction bureau id'
     field :content, String, description: 'markdown content'
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'created_at'

--- a/app/graphql/types/committee_type.rb
+++ b/app/graphql/types/committee_type.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Types
+  class CommitteeType < Types::BaseObject
+    description 'article tags'
+
+    field :bureau_id, Integer, description: 'jurisdiction bureau id'
+    field :content, String, description: 'markdown content'
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'created_at'
+    field :description, String, null: false, description: 'short description'
+    field :id, ID, null: false, description: 'id'
+    field :name, String, null: false, description: 'name'
+    field :slug, String, null: false, description: 'search keyword'
+    field :special, Boolean, null: false, description: 'is special committee'
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'updated_at'
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -7,5 +7,6 @@ module Types
     field :articles, resolver: Resolvers::ArticlesResolver, description: 'all published articles'
     field :bureau, resolver: Resolvers::BureauResolver, description: 'single bureau with slug'
     field :bureaus, resolver: Resolvers::BureausResolver, description: 'all bureaus'
+    field :committees, resolver: Resolvers::CommitteesResolver, description: 'all committees'
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -7,6 +7,7 @@ module Types
     field :articles, resolver: Resolvers::ArticlesResolver, description: 'all published articles'
     field :bureau, resolver: Resolvers::BureauResolver, description: 'single bureau with slug'
     field :bureaus, resolver: Resolvers::BureausResolver, description: 'all bureaus'
-    field :committees, resolver: Resolvers::CommitteesResolver, description: 'all committees'
+    field :committee, resolver: Resolvers::CommitteeResolver, description: 'committee detail'
+    field :committees, resolver: Resolvers::CommitteesResolver, description: 'all committees list'
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -7,5 +7,17 @@ FactoryBot.define do
     trait :published do
       published_at { Time.current }
     end
+
+    trait :with_bureau do
+      after(:build) do |article|
+        article.bureaus << build(:bureau)
+      end
+    end
+
+    trait :with_committee do
+      after(:build) do |article|
+        article.committees << build(:committee)
+      end
+    end
   end
 end

--- a/spec/requests/graphql/article_spec.rb
+++ b/spec/requests/graphql/article_spec.rb
@@ -1,18 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Article' do
-  describe 'POST /graphql' do
-    subject(:request) { post '/graphql', params: { query: } }
+  subject(:response_nodes) { response_data[:nodes] }
 
-    let(:response_data) { JSON.parse(response.body, symbolize_names: true).dig(:data, :articles) }
-    let(:response_nodes) { response_data[:nodes] }
+  let(:request) { post '/graphql', params: { query: } }
 
-    before do
-      create_list(:article, 7, :published)
-      create_list(:article, 3)
-    end
+  let(:response_data) { JSON.parse(response.body, symbolize_names: true).dig(:data, :articles) }
 
+  describe 'articles query' do
     context 'when requests articles query' do
+      before do
+        create_list(:article, 7, :published)
+        create_list(:article, 3)
+      end
+
       let(:query) do
         <<~QUERY
           {
@@ -42,6 +43,11 @@ RSpec.describe 'Article' do
     end
 
     context 'when requests articles query small first' do
+      before do
+        create_list(:article, 7, :published)
+        create_list(:article, 3)
+      end
+
       let(:query) do
         <<~QUERY
           {
@@ -66,6 +72,41 @@ RSpec.describe 'Article' do
       it 'has specified number of articles in first' do
         request
         expect(response_nodes.length).to eq 3
+        expect(response_data).to eq expected_data
+      end
+    end
+
+    context 'when article has jurisdiction bureaus and committees' do
+      let!(:article) { create(:article, :with_bureau, :with_committee, :published) }
+
+      let(:query) do
+        <<~QUERY
+          {
+            articles(first: 5){
+              nodes{
+                bureaus{
+                  name
+                }
+                committees{
+                  name
+                }
+              }
+            }
+          }
+        QUERY
+      end
+
+      let(:expected_data) do
+        {
+          nodes: [{
+            bureaus: [{ name: article.bureaus.first.name }],
+            committees: [{ name: article.committees.first.name }]
+          }]
+        }
+      end
+
+      it 'returns expected data' do
+        request
         expect(response_data).to eq expected_data
       end
     end

--- a/spec/requests/graphql/committee_spec.rb
+++ b/spec/requests/graphql/committee_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'Committee' do
+  subject(:request) { post '/graphql', params: { query: } }
+
+  # NOTE: 3-1-5-2-4の順が正しい
+  let!(:first_committee) { create(:committee) }
+  let!(:second_committee) { create(:committee, :with_bureau) }
+  let!(:third_committee) { create(:committee, :special) }
+  let!(:fourth_committee) { create(:committee, :with_bureau) }
+  let!(:fifth_committee) { create(:committee, :with_bureau, :special, bureau: Bureau.first) }
+
+  describe 'committees query' do
+    subject(:result) { JSON.parse(response.body, symbolize_names: true).dig(:data, :committees) }
+
+    let(:query) do
+      <<~QUERY
+        {
+          committees{
+            id
+          }
+        }
+      QUERY
+    end
+
+    let(:expected_data) do
+      [{ id: third_committee.id.to_s }, { id: first_committee.id.to_s }, { id: fifth_committee.id.to_s },
+       { id: second_committee.id.to_s }, { id: fourth_committee.id.to_s }]
+    end
+
+    it 'returns expected_data' do
+      request
+      expect(result).to eq expected_data
+    end
+  end
+end

--- a/spec/requests/graphql/committee_spec.rb
+++ b/spec/requests/graphql/committee_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe 'Committee' do
           committee(slug: "#{committee.slug}"){
             name
             special
-            bureauId
+            bureau{
+              name
+            }
             articles(first: 5){
               nodes{
                 title
@@ -60,7 +62,9 @@ RSpec.describe 'Committee' do
       {
         name: committee.name,
         special: true,
-        bureauId: committee.bureau.id,
+        bureau:{
+          name: committee.bureau.name
+        },
         articles: {
           nodes: [
             { title: article.title }

--- a/spec/requests/graphql/committee_spec.rb
+++ b/spec/requests/graphql/committee_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Committee' do
       {
         name: committee.name,
         special: true,
-        bureau:{
+        bureau: {
           name: committee.bureau.name
         },
         articles: {


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] closeする各Issueの受け入れ条件をすべて満たしている
- [x] 実装ページや機能があればそれをWikiに掲載した
# Issue
- close #181 
## Epic
- #159 
## 目的
委員会関連の機能をフロントエンドから利用できるようにする
## 実装詳細
- Gemfile.lock
  - pumaのdependabot対応
- app/graphql/resolvers/committee_resolver.rb
- app/graphql/resolvers/committees_resolver.rb
  - 委員会詳細、委員会一覧のresolver
  - 委員会一覧は指定された順序で並べるscopeを使っている
- app/graphql/types/article_type.rb
  - 記事から管轄委員会を取得できるようにする
- app/graphql/types/committee_type.rb
  - 委員会のtype
  - フィールドは一通り定義されている
- spec/factories/articles.rb
  - 記事と同時に委員会や局を作るtraitを作成する
## 動作
- [x] GraphQL で委員会の一覧を以下の条件で取得できる
  - 局ごと、局のID順
  - 独立委員会は最初に表示
- [x] GraphQL で記事の管轄委員会を取得できる
- [x] GraphQL で委員会の詳細を取得できる

## レビュー観点

## デプロイ種別
### 種別（選択）
- パッチリリース
### 追加作業／確認項目
- 
## メモ
- #179 も含んでいる